### PR TITLE
fix: link to ci.rs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then you can start creating GitHub Actions in your [tests/ci.rs](https://github.
   }
   ```
 
-  To view a fully functional example, check out the [tests/ci.rs](https://github.com/tailcallhq/rust-gh-workflow/blob/main/src/tests/ci.rs) of this project.
+  To view a fully functional example, check out the [tests/ci.rs](https://github.com/tailcallhq/rust-gh-workflow/blob/main/tests/ci.rs) of this project.
 
 - Run `cargo test` to generate the GitHub Actions workflow.
 


### PR DESCRIPTION
Fix 404 link for ci.rs