### PR TITLE
feat: add `WorkflowCall::add_input`

### DIFF
--- a/crates/gh-workflow/src/event.rs
+++ b/crates/gh-workflow/src/event.rs
@@ -808,6 +808,13 @@ pub struct WorkflowCall {
     pub secrets: HashMap<String, WorkflowCallSecret>,
 }
 
+impl WorkflowCall {
+    pub fn add_input(mut self, name: impl Into<String>, input: WorkflowCallInput) -> Self {
+        self.inputs.insert(name.into(), input);
+        self
+    }
+}
+
 /// Configuration for workflow call input
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Setters, Eq)]
 #[setters(strip_option, into)]


### PR DESCRIPTION
We're trying to use gh-workflow at Zed (https://github.com/zed-industries/zed) and needed this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fluent API method for adding inputs to workflow calls, enabling developers to more conveniently configure workflow inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->