### PR TITLE
docs: update the usage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GitHub Actions is powerful, but writing workflows can sometimes feel repetitive,
 To use **Rust GitHub Workflows** in your project, add it to your `Cargo.toml`:
 
 ```toml
-[build-dependencies]
+[dev-dependencies]
 gh-workflow = "*" # Add the latest version
 ```
 
@@ -35,7 +35,7 @@ Then you can start creating GitHub Actions in your [tests/ci.rs](https://github.
 - Add the following code to generate the GitHub Actions workflow:
 
   ```rust
-  use gh_workflows::*;
+  use gh_workflow::*;
 
   #[test]
   fn main() {


### PR DESCRIPTION
We use `build-dependencies` only when `build.rs` needs dependencies, for test case, `dev-dependencies` is correct way.

One more thing is in example code, is `use gh_workflows::*` outdated? I remove the `s` then success to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed dependency specification and import path references in code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->